### PR TITLE
Fix docker-compose file and README so that the app can be run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ REST API was chosen due to its stateless nature.
 ## Local run with Docker
 
 - Install Docker
+- Clone the git repository
+- In the git repository run nmp install
 - In the git repository run command: " docker-compose up "
 - Go to `http://localhost:9000/` to check if running correctly.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ REST API was chosen due to its stateless nature.
 
 - Install Docker
 - Clone the git repository
-- In the git repository run nmp install
+- In the git repository run npm install
 - In the git repository run command: " docker-compose up "
 - Go to `http://localhost:9000/` to check if running correctly.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
   mongo:
     container_name: mongo
     image: mongo
+    hostname: mongo
     volumes:
       - mongodb_data:/data/db 
     ports:
@@ -32,6 +33,10 @@ services:
       - rabbitmq
     environment:
       WAIT_HOSTS: mongo:27017, rabbitmq:5672
+      RABBITMQ_URL: rabbitmq:5672
+      MONGODB_URL: mongo:27017
+      RABBITMQ_USER: rabbitmquser
+      RABBITMQ_PASSWORD: rabbitmqpassword
   rabbitmq:
    image: rabbitmq:3.7-management
    container_name: rabbitmq


### PR DESCRIPTION
### Applicable Issues
[#1](https://github.com/eiffel-community/simple-event-sender/issues/1) 

### Description of the Change
Added instructions to run npm install before starting docker and added environment variables to the docker-compose file that were expected by the simple-event-sender application so that the docker-compose up command works locally.

### Alternate Designs


### Benefits
docker-compose up works.

### Possible Drawbacks


### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Kristofer Hallén kristofer.hallen@ericsson.com 
